### PR TITLE
Lead detail PR1: dynamic Airtable IDs for leads APIs, faster /api/users, Select fix

### DIFF
--- a/src/app/api/leads/[id]/route.ts
+++ b/src/app/api/leads/[id]/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getAirtableKey } from '@/lib/api-keys-service';
+import { getAirtableKey, getAirtableBaseId, getAirtableLeadsTableId } from '@/lib/api-keys-service';
 import { leadsCache } from '@/lib/leads-cache';
 import { LeadFormData } from '@/types/leads';
-
-const AIRTABLE_BASE_ID = 'app359c17lK0Ta8Ws';
-const LEADS_TABLE_ID = 'tblKIZ9CDjcQorONA';
 
 /**
  * GET /api/leads/[id] - Get single lead by ID
@@ -13,8 +10,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  const { id } = await params;
   try {
-    const leadId = params.id;
+    const leadId = id;
     
     if (!leadId) {
       return NextResponse.json(
@@ -23,11 +21,15 @@ export async function GET(
       );
     }
 
-    // Get Airtable API key
-    const apiKey = await getAirtableKey();
-    if (!apiKey) {
+    // Get Airtable credentials
+    const [apiKey, baseId, tableId] = await Promise.all([
+      getAirtableKey(),
+      getAirtableBaseId(),
+      getAirtableLeadsTableId(),
+    ]);
+    if (!apiKey || !baseId || !tableId) {
       return NextResponse.json(
-        { error: 'Airtable API key not available' },
+        { error: 'Airtable credentials not available' },
         { status: 500 }
       );
     }
@@ -35,7 +37,7 @@ export async function GET(
     console.log(`🔍 [GET LEAD] Fetching lead: ${leadId}`);
 
     // Call Airtable API to get single record
-    const airtableUrl = `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${LEADS_TABLE_ID}/${leadId}`;
+    const airtableUrl = `https://api.airtable.com/v0/${baseId}/${tableId}/${leadId}`;
     
     const response = await fetch(airtableUrl, {
       headers: {
@@ -94,8 +96,9 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  const { id } = await params;
   try {
-    const leadId = params.id;
+    const leadId = id;
     const body: Partial<LeadFormData> = await request.json();
     
     if (!leadId) {
@@ -107,11 +110,15 @@ export async function PUT(
 
     console.log('🔄 [UPDATE LEAD] Received data:', { leadId, body });
 
-    // Get Airtable API key
-    const apiKey = await getAirtableKey();
-    if (!apiKey) {
+    // Get Airtable credentials
+    const [apiKey, baseId, tableId] = await Promise.all([
+      getAirtableKey(),
+      getAirtableBaseId(),
+      getAirtableLeadsTableId(),
+    ]);
+    if (!apiKey || !baseId || !tableId) {
       return NextResponse.json(
-        { error: 'Airtable API key not available' },
+        { error: 'Airtable credentials not available' },
         { status: 500 }
       );
     }
@@ -139,7 +146,7 @@ export async function PUT(
     console.log('📤 [UPDATE LEAD] Sending to Airtable:', airtableData);
 
     // Chiamata API Airtable per aggiornare il record
-    const airtableUrl = `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${LEADS_TABLE_ID}/${leadId}`;
+    const airtableUrl = `https://api.airtable.com/v0/${baseId}/${tableId}/${leadId}`;
     
     const response = await fetch(airtableUrl, {
       method: 'PATCH',
@@ -202,8 +209,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  const { id } = await params;
   try {
-    const leadId = params.id;
+    const leadId = id;
     
     if (!leadId) {
       return NextResponse.json(
@@ -212,11 +220,15 @@ export async function DELETE(
       );
     }
 
-    // Get Airtable API key
-    const apiKey = await getAirtableKey();
-    if (!apiKey) {
+    // Get Airtable credentials
+    const [apiKey, baseId, tableId] = await Promise.all([
+      getAirtableKey(),
+      getAirtableBaseId(),
+      getAirtableLeadsTableId(),
+    ]);
+    if (!apiKey || !baseId || !tableId) {
       return NextResponse.json(
-        { error: 'Airtable API key not available' },
+        { error: 'Airtable credentials not available' },
         { status: 500 }
       );
     }
@@ -224,7 +236,7 @@ export async function DELETE(
     console.log(`🗑️ [DELETE LEAD] Attempting to delete lead: ${leadId}`);
 
     // Chiamata API Airtable per eliminare il record
-    const airtableUrl = `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${LEADS_TABLE_ID}/${leadId}`;
+    const airtableUrl = `https://api.airtable.com/v0/${baseId}/${tableId}/${leadId}`;
     
     const response = await fetch(airtableUrl, {
       method: 'DELETE',

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -37,6 +37,12 @@ async function fetchAllUsers(
   try {
     do {
       const url = new URL(`https://api.airtable.com/v0/${baseId}/${tableId}`);
+      // Limit fields to reduce payload and improve performance
+      url.searchParams.append('fields[]', 'Nome');
+      url.searchParams.append('fields[]', 'Email');
+      url.searchParams.append('fields[]', 'Ruolo');
+      url.searchParams.append('fields[]', 'Avatar');
+      url.searchParams.append('fields[]', 'Telefono');
 
       if (offset) {
         url.searchParams.append('offset', offset);
@@ -49,6 +55,7 @@ async function fetchAllUsers(
           Authorization: `Bearer ${apiKey}`,
           'Content-Type': 'application/json',
         },
+        next: { revalidate: 300 },
       });
 
       if (!response.ok) {

--- a/src/components/leads-detail/Header.tsx
+++ b/src/components/leads-detail/Header.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { AvatarLead } from '@/components/ui/avatar-lead';
+import { Phone, Mail, ArrowLeft, Trash2, Pencil } from 'lucide-react';
+import { LeadData, LeadFormData, LeadStato } from '@/types/leads';
+import { cn } from '@/lib/utils';
+
+interface UsersLookup {
+  [userId: string]: {
+    nome: string;
+    ruolo: string;
+    avatar?: string;
+  };
+}
+
+interface HeaderProps {
+  lead: LeadData;
+  usersData?: UsersLookup | null;
+  onBack: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onCall: () => void;
+  onEmail: () => void;
+  onUpdate: (data: Partial<LeadFormData>) => Promise<boolean> | void;
+}
+
+const STATI: LeadStato[] = ['Nuovo', 'Attivo', 'Qualificato', 'Cliente', 'Chiuso', 'Sospeso'];
+
+export function LeadDetailHeader({
+  lead,
+  usersData,
+  onBack,
+  onEdit,
+  onDelete,
+  onCall,
+  onEmail,
+  onUpdate,
+}: HeaderProps) {
+  const assegnatarioId = lead.Assegnatario?.[0];
+  const assegnatarioName = assegnatarioId && usersData ? usersData[assegnatarioId]?.nome : undefined;
+
+  return (
+    <Card className="p-4 md:p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        {/* Left: identity */}
+        <div className="flex items-center gap-4">
+          <AvatarLead nome={lead.Nome || lead.ID} size="xl" showTooltip={false} />
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <h1 className="text-xl md:text-2xl font-semibold tracking-tight">
+                {lead.Nome || lead.ID}
+              </h1>
+              <Badge variant="secondary" className="text-xs">{lead.ID}</Badge>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <Badge variant="outline">{lead.Provenienza}</Badge>
+              <span>•</span>
+              <span>Stato:</span>
+              <Select
+                defaultValue={lead.Stato}
+                onValueChange={(value) => onUpdate({ Stato: value as LeadStato })}
+              >
+                <SelectTrigger className="h-7 w-[160px]">
+                  <SelectValue placeholder="Stato" />
+                </SelectTrigger>
+                <SelectContent>
+                  {STATI.map((s) => (
+                    <SelectItem key={s} value={s}>{s}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <span>•</span>
+              <span>Assegnatario:</span>
+              <Select
+                value={assegnatarioId || 'none'}
+                onValueChange={(value) => onUpdate({ Assegnatario: value === 'none' ? [] : [value] })}
+              >
+                <SelectTrigger className="h-7 w-[200px]">
+                  <SelectValue placeholder={assegnatarioName || 'Non assegnato'} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem key="none" value="none">Non assegnato</SelectItem>
+                  {usersData && Object.entries(usersData).map(([id, u]) => (
+                    <SelectItem key={id} value={id}>{u.nome}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+
+        {/* Right: actions */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="outline" onClick={onBack}>
+            <ArrowLeft className="mr-2 h-4 w-4" /> Indietro
+          </Button>
+          {lead.Telefono && (
+            <Button variant="outline" onClick={onCall}>
+              <Phone className="mr-2 h-4 w-4" /> Chiama
+            </Button>
+          )}
+          {lead.Email && (
+            <Button variant="outline" onClick={onEmail}>
+              <Mail className="mr-2 h-4 w-4" /> Email
+            </Button>
+          )}
+          <Button variant="outline" onClick={onEdit}>
+            <Pencil className="mr-2 h-4 w-4" /> Modifica
+          </Button>
+          <Button variant="destructive" onClick={onDelete}>
+            <Trash2 className="mr-2 h-4 w-4" /> Elimina
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+


### PR DESCRIPTION
Changes:\n- refactor(api/leads): use getAirtableKey/getAirtableBaseId/getAirtableLeadsTableId (no hardcoded IDs)\n- perf(api/users): request only needed fields + 5m revalidate\n- fix(leads-detail/Header): non-empty value ("none") for 'Non assegnato' option\n\nWhy:\n- Align to unified API keys system\n- Reduce payload/time for users\n- Fix runtime error on SelectItem value\n\nTesting:\n- Lead detail loads\n- /api/users returns 200 and users map\n- Header Select works without errors