### PR TITLE
Lead detail PR6: Activities performance (120s revalidate + cache) and quieter logs

### DIFF
--- a/src/app/api/leads/[id]/route.ts
+++ b/src/app/api/leads/[id]/route.ts
@@ -138,6 +138,13 @@ export async function PUT(
     if (body.Note !== undefined) fieldsToUpdate.Note = body.Note.trim();
     if (body.Assegnatario !== undefined) fieldsToUpdate.Assegnatario = body.Assegnatario;
     if (body.Referenza !== undefined) fieldsToUpdate.Referenza = body.Referenza;
+    if (body.Allegati !== undefined && Array.isArray(body.Allegati)) {
+      // Airtable accetta array di oggetti con almeno { url, filename }
+      fieldsToUpdate.Allegati = body.Allegati.map((a: any) => ({
+        url: a.url,
+        filename: a.filename,
+      })).filter((a: any) => a.url);
+    }
 
     const airtableData = {
       fields: fieldsToUpdate,

--- a/src/app/api/leads/[id]/route.ts
+++ b/src/app/api/leads/[id]/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getAirtableKey } from '@/lib/api-keys-service';
+import { getAirtableKey, getAirtableBaseId, getAirtableLeadsTableId } from '@/lib/api-keys-service';
 import { leadsCache } from '@/lib/leads-cache';
 import { LeadFormData } from '@/types/leads';
-
-const AIRTABLE_BASE_ID = 'app359c17lK0Ta8Ws';
-const LEADS_TABLE_ID = 'tblKIZ9CDjcQorONA';
 
 /**
  * GET /api/leads/[id] - Get single lead by ID
@@ -13,8 +10,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  const { id } = await params;
   try {
-    const leadId = params.id;
+    const leadId = id;
     
     if (!leadId) {
       return NextResponse.json(
@@ -23,11 +21,15 @@ export async function GET(
       );
     }
 
-    // Get Airtable API key
-    const apiKey = await getAirtableKey();
-    if (!apiKey) {
+    // Get Airtable credentials
+    const [apiKey, baseId, tableId] = await Promise.all([
+      getAirtableKey(),
+      getAirtableBaseId(),
+      getAirtableLeadsTableId(),
+    ]);
+    if (!apiKey || !baseId || !tableId) {
       return NextResponse.json(
-        { error: 'Airtable API key not available' },
+        { error: 'Airtable credentials not available' },
         { status: 500 }
       );
     }
@@ -35,7 +37,7 @@ export async function GET(
     console.log(`🔍 [GET LEAD] Fetching lead: ${leadId}`);
 
     // Call Airtable API to get single record
-    const airtableUrl = `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${LEADS_TABLE_ID}/${leadId}`;
+    const airtableUrl = `https://api.airtable.com/v0/${baseId}/${tableId}/${leadId}`;
     
     const response = await fetch(airtableUrl, {
       headers: {
@@ -94,8 +96,9 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  const { id } = await params;
   try {
-    const leadId = params.id;
+    const leadId = id;
     const body: Partial<LeadFormData> = await request.json();
     
     if (!leadId) {
@@ -107,11 +110,15 @@ export async function PUT(
 
     console.log('🔄 [UPDATE LEAD] Received data:', { leadId, body });
 
-    // Get Airtable API key
-    const apiKey = await getAirtableKey();
-    if (!apiKey) {
+    // Get Airtable credentials
+    const [apiKey, baseId, tableId] = await Promise.all([
+      getAirtableKey(),
+      getAirtableBaseId(),
+      getAirtableLeadsTableId(),
+    ]);
+    if (!apiKey || !baseId || !tableId) {
       return NextResponse.json(
-        { error: 'Airtable API key not available' },
+        { error: 'Airtable credentials not available' },
         { status: 500 }
       );
     }
@@ -139,7 +146,7 @@ export async function PUT(
     console.log('📤 [UPDATE LEAD] Sending to Airtable:', airtableData);
 
     // Chiamata API Airtable per aggiornare il record
-    const airtableUrl = `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${LEADS_TABLE_ID}/${leadId}`;
+    const airtableUrl = `https://api.airtable.com/v0/${baseId}/${tableId}/${leadId}`;
     
     const response = await fetch(airtableUrl, {
       method: 'PATCH',
@@ -202,8 +209,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  const { id } = await params;
   try {
-    const leadId = params.id;
+    const leadId = id;
     
     if (!leadId) {
       return NextResponse.json(
@@ -212,11 +220,15 @@ export async function DELETE(
       );
     }
 
-    // Get Airtable API key
-    const apiKey = await getAirtableKey();
-    if (!apiKey) {
+    // Get Airtable credentials
+    const [apiKey, baseId, tableId] = await Promise.all([
+      getAirtableKey(),
+      getAirtableBaseId(),
+      getAirtableLeadsTableId(),
+    ]);
+    if (!apiKey || !baseId || !tableId) {
       return NextResponse.json(
-        { error: 'Airtable API key not available' },
+        { error: 'Airtable credentials not available' },
         { status: 500 }
       );
     }
@@ -224,7 +236,7 @@ export async function DELETE(
     console.log(`🗑️ [DELETE LEAD] Attempting to delete lead: ${leadId}`);
 
     // Chiamata API Airtable per eliminare il record
-    const airtableUrl = `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${LEADS_TABLE_ID}/${leadId}`;
+    const airtableUrl = `https://api.airtable.com/v0/${baseId}/${tableId}/${leadId}`;
     
     const response = await fetch(airtableUrl, {
       method: 'DELETE',

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAirtableKey, getAirtableBaseId, getAirtableOrdersTableId } from '@/lib/api-keys-service';
+
+function parseIds(searchParams: URLSearchParams): string[] {
+  // Support both ids=rec1,rec2 and ids[]=rec1&ids[]=rec2
+  const idsParams = searchParams.getAll('ids');
+  const list: string[] = [];
+  for (const param of idsParams) {
+    const parts = param.split(',').map(s => s.trim()).filter(Boolean);
+    list.push(...parts);
+  }
+  // Also support id=rec1 (single)
+  const single = searchParams.get('id');
+  if (single) list.push(single);
+  // Deduplicate
+  return Array.from(new Set(list));
+}
+
+/**
+ * GET /api/orders?ids=recA,recB or /api/orders?ids=recA&ids=recB
+ * Returns a simplified list of orders with common fields when available.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const ids = parseIds(searchParams);
+
+    if (!ids.length) {
+      return NextResponse.json(
+        { error: 'ids query parameter is required' },
+        { status: 400 }
+      );
+    }
+
+    const [apiKey, baseId, tableId] = await Promise.all([
+      getAirtableKey(),
+      getAirtableBaseId(),
+      getAirtableOrdersTableId(),
+    ]);
+
+    if (!apiKey || !baseId || !tableId) {
+      return NextResponse.json(
+        { error: 'Airtable credentials not available' },
+        { status: 500 }
+      );
+    }
+
+    // Build filterByFormula: OR(RECORD_ID()='rec1', RECORD_ID()='rec2', ...)
+    const formula = `OR(${ids.map(id => `RECORD_ID()='${id}'`).join(',')})`;
+    const url = new URL(`https://api.airtable.com/v0/${baseId}/${tableId}`);
+    url.searchParams.set('filterByFormula', formula);
+    url.searchParams.set('maxRecords', String(Math.min(ids.length, 100)));
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      next: { revalidate: 120 },
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      console.error('[Orders] Airtable API error:', response.status, errText);
+      return NextResponse.json(
+        { error: `Airtable API error: ${response.status}` },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+
+    // Transform records to a simple structure. Field names are optional.
+    const records = (data.records || []).map((record: any) => {
+      const f = record.fields || {};
+      return {
+        id: record.id,
+        createdTime: record.createdTime,
+        // Common optional fields (if present in Airtable)
+        Data: f.Data || null,
+        Totale: f.Totale ?? null,
+        Stato: f.Stato || null,
+        Numero: f['Numero Ordine'] || f.Numero || null,
+        ...f, // also return all fields for flexibility on the client
+      };
+    });
+
+    return NextResponse.json({ success: true, count: records.length, records });
+  } catch (error) {
+    console.error('[Orders] Error:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch orders' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -37,6 +37,12 @@ async function fetchAllUsers(
   try {
     do {
       const url = new URL(`https://api.airtable.com/v0/${baseId}/${tableId}`);
+      // Limit fields to reduce payload and improve performance
+      url.searchParams.append('fields[]', 'Nome');
+      url.searchParams.append('fields[]', 'Email');
+      url.searchParams.append('fields[]', 'Ruolo');
+      url.searchParams.append('fields[]', 'Avatar');
+      url.searchParams.append('fields[]', 'Telefono');
 
       if (offset) {
         url.searchParams.append('offset', offset);
@@ -49,6 +55,7 @@ async function fetchAllUsers(
           Authorization: `Bearer ${apiKey}`,
           'Content-Type': 'application/json',
         },
+        next: { revalidate: 300 },
       });
 
       if (!response.ok) {

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -36,34 +36,50 @@ async function fetchAllUsers(
 
   try {
     do {
-      const url = new URL(`https://api.airtable.com/v0/${baseId}/${tableId}`);
-      // Limit fields to reduce payload and improve performance
-      url.searchParams.append('fields[]', 'Nome');
-      url.searchParams.append('fields[]', 'Email');
-      url.searchParams.append('fields[]', 'Ruolo');
-      url.searchParams.append('fields[]', 'Avatar');
-      url.searchParams.append('fields[]', 'Telefono');
+      const baseUrl = `https://api.airtable.com/v0/${baseId}/${tableId}`;
 
-      if (offset) {
-        url.searchParams.append('offset', offset);
+      const buildUrl = (includeFields: boolean) => {
+        const u = new URL(baseUrl);
+        if (offset) {
+          u.searchParams.append('offset', offset);
+        }
+        if (includeFields) {
+          u.searchParams.append('fields[]', 'Nome');
+          u.searchParams.append('fields[]', 'Email');
+          u.searchParams.append('fields[]', 'Ruolo');
+          u.searchParams.append('fields[]', 'Avatar');
+          u.searchParams.append('fields[]', 'Telefono');
+        }
+        return u;
+      };
+
+      let response: Response;
+
+      const doFetch = async (fullUrl: string) =>
+        fetch(fullUrl, {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          next: { revalidate: 300 },
+        });
+
+      // First attempt with fields[]
+      const urlTryFields = buildUrl(true);
+      console.log('🔗 Fetching users from:', urlTryFields.toString());
+      response = await doFetch(urlTryFields.toString());
+
+      // Fallback: remove fields[] if Airtable rejects with 422
+      if (response.status === 422) {
+        console.warn('⚠️ Airtable 422 with fields[] filter. Retrying without fields...');
+        const urlNoFields = buildUrl(false);
+        console.log('🔁 Retrying users fetch:', urlNoFields.toString());
+        response = await doFetch(urlNoFields.toString());
       }
 
-      console.log('🔗 Fetching users from:', url.toString());
-
-      const response = await fetch(url.toString(), {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        next: { revalidate: 300 },
-      });
-
       if (!response.ok) {
-        console.error(
-          '❌ Airtable API error:',
-          response.status,
-          response.statusText
-        );
+        const errText = await response.text();
+        console.error('❌ Airtable API error:', response.status, errText);
         throw new Error(
           `Airtable API error: ${response.status} ${response.statusText}`
         );

--- a/src/components/leads-detail/FilesPanel.tsx
+++ b/src/components/leads-detail/FilesPanel.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Paperclip } from 'lucide-react';
+import { toast } from 'sonner';
+import { LeadData, AirtableAttachment } from '@/types/leads';
+
+interface FilesPanelProps {
+  lead: LeadData;
+}
+
+export function FilesPanel({ lead }: FilesPanelProps) {
+  const [attachments, setAttachments] = useState<AirtableAttachment[]>(
+    (lead.Allegati || []) as AirtableAttachment[]
+  );
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputId = `file-input-${lead.id}`;
+
+  const ALLOWED_TYPES = [
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'text/plain',
+  ];
+
+  const handleUpload = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    setError(null);
+    setUploading(true);
+
+    try {
+      const uploaded: any[] = [];
+      for (const file of Array.from(files)) {
+        if (!ALLOWED_TYPES.includes(file.type)) {
+          setError(`Tipo non supportato: ${file.name}`);
+          continue;
+        }
+        if (file.size > 10 * 1024 * 1024) {
+          setError(`File troppo grande (max 10MB): ${file.name}`);
+          continue;
+        }
+        const formData = new FormData();
+        formData.append('file', file);
+        const res = await fetch('/api/upload', { method: 'POST', body: formData });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || `Upload failed for ${file.name}`);
+        }
+        const json = await res.json();
+        uploaded.push(json.attachment);
+      }
+
+      if (uploaded.length > 0) {
+        // Aggiorna il lead con i nuovi allegati
+        const newAllegati = [...attachments, ...uploaded];
+        const res2 = await fetch(`/api/leads/${lead.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ Allegati: newAllegati }),
+        });
+        if (!res2.ok) {
+          const err = await res2.json().catch(() => ({}));
+          throw new Error(err.error || 'Aggiornamento lead fallito');
+        }
+        const updated = await res2.json();
+        setAttachments((updated.lead?.Allegati || []) as AirtableAttachment[]);
+        toast.success(`${uploaded.length} file caricati`);
+      }
+    } catch (e) {
+      console.error('❌ Upload error:', e);
+      setError(e instanceof Error ? e.message : 'Errore upload');
+      toast.error('Errore durante l\'upload');
+    } finally {
+      setUploading(false);
+      // Reset input
+      const input = document.getElementById(fileInputId) as HTMLInputElement | null;
+      if (input) input.value = '';
+    }
+  };
+
+  const handleRemove = async (attachmentId: string) => {
+    try {
+      const remaining = attachments.filter(a => a.id !== attachmentId);
+      const res = await fetch(`/api/leads/${lead.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ Allegati: remaining }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || 'Aggiornamento lead fallito');
+      }
+      const updated = await res.json();
+      setAttachments((updated.lead?.Allegati || []) as AirtableAttachment[]);
+      toast.success('Allegato rimosso');
+    } catch (e) {
+      console.error('❌ Remove attachment error:', e);
+      toast.error('Errore rimozione allegato');
+    }
+  };
+
+  const handleCopy = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success('Link copiato');
+    } catch {
+      toast.error('Impossibile copiare il link');
+    }
+  };
+
+  return (
+    <Card className="p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="font-semibold">Allegati</div>
+        <div className="flex items-center gap-2">
+          <input
+            id={fileInputId}
+            type="file"
+            multiple
+            accept={ALLOWED_TYPES.join(',')}
+            className="hidden"
+            onChange={(e) => handleUpload(e.target.files)}
+          />
+          <label htmlFor={fileInputId}>
+            <Button size="sm" disabled={uploading}>
+              {uploading ? 'Caricamento...' : 'Carica file'}
+            </Button>
+          </label>
+        </div>
+      </div>
+
+      {error && <div className="text-xs text-red-600">{error}</div>}
+
+      {attachments.length === 0 ? (
+        <div className="text-muted-foreground">Nessun allegato</div>
+      ) : (
+        <ul className="space-y-2">
+          {attachments.map((f) => (
+            <li key={f.id} className="flex items-center gap-2 text-sm">
+              <Paperclip className="h-3.5 w-3.5 text-muted-foreground" />
+              <a href={f.url} target="_blank" rel="noreferrer" className="underline underline-offset-2">
+                {f.filename}
+              </a>
+              {typeof f.size === 'number' && (
+                <span className="text-muted-foreground">({Math.round(f.size / 1024)} KB)</span>
+              )}
+              <div className="ml-auto flex items-center gap-2">
+                <Button variant="outline" size="xs" onClick={() => handleCopy(f.url)}>Copia link</Button>
+                <Button variant="destructive" size="xs" onClick={() => handleRemove(f.id)}>Rimuovi</Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+

--- a/src/components/leads-detail/Header.tsx
+++ b/src/components/leads-detail/Header.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { AvatarLead } from '@/components/ui/avatar-lead';
+import { Phone, Mail, ArrowLeft, Trash2, Pencil } from 'lucide-react';
+import { LeadData, LeadFormData, LeadStato } from '@/types/leads';
+import { cn } from '@/lib/utils';
+
+interface UsersLookup {
+  [userId: string]: {
+    nome: string;
+    ruolo: string;
+    avatar?: string;
+  };
+}
+
+interface HeaderProps {
+  lead: LeadData;
+  usersData?: UsersLookup | null;
+  onBack: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onCall: () => void;
+  onEmail: () => void;
+  onUpdate: (data: Partial<LeadFormData>) => Promise<boolean> | void;
+}
+
+const STATI: LeadStato[] = ['Nuovo', 'Attivo', 'Qualificato', 'Cliente', 'Chiuso', 'Sospeso'];
+
+export function LeadDetailHeader({
+  lead,
+  usersData,
+  onBack,
+  onEdit,
+  onDelete,
+  onCall,
+  onEmail,
+  onUpdate,
+}: HeaderProps) {
+  const assegnatarioId = lead.Assegnatario?.[0];
+  const assegnatarioName = assegnatarioId && usersData ? usersData[assegnatarioId]?.nome : undefined;
+
+  return (
+    <Card className="p-4 md:p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        {/* Left: identity */}
+        <div className="flex items-center gap-4">
+          <AvatarLead nome={lead.Nome || lead.ID} size="xl" showTooltip={false} />
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <h1 className="text-xl md:text-2xl font-semibold tracking-tight">
+                {lead.Nome || lead.ID}
+              </h1>
+              <Badge variant="secondary" className="text-xs">{lead.ID}</Badge>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <Badge variant="outline">{lead.Provenienza}</Badge>
+              <span>•</span>
+              <span>Stato:</span>
+              <Select
+                defaultValue={lead.Stato}
+                onValueChange={(value) => onUpdate({ Stato: value as LeadStato })}
+              >
+                <SelectTrigger className="h-7 w-[160px]">
+                  <SelectValue placeholder="Stato" />
+                </SelectTrigger>
+                <SelectContent>
+                  {STATI.map((s) => (
+                    <SelectItem key={s} value={s}>{s}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <span>•</span>
+              <span>Assegnatario:</span>
+              <Select
+                value={assegnatarioId || 'none'}
+                onValueChange={(value) => onUpdate({ Assegnatario: value === 'none' ? [] : [value] })}
+              >
+                <SelectTrigger className="h-7 w-[200px]">
+                  <SelectValue placeholder={assegnatarioName || 'Non assegnato'} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem key="none" value="none">Non assegnato</SelectItem>
+                  {usersData && Object.entries(usersData).map(([id, u]) => (
+                    <SelectItem key={id} value={id}>{u.nome}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+
+        {/* Right: actions */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="outline" onClick={onBack}>
+            <ArrowLeft className="mr-2 h-4 w-4" /> Indietro
+          </Button>
+          {lead.Telefono && (
+            <Button variant="outline" onClick={onCall}>
+              <Phone className="mr-2 h-4 w-4" /> Chiama
+            </Button>
+          )}
+          {lead.Email && (
+            <Button variant="outline" onClick={onEmail}>
+              <Mail className="mr-2 h-4 w-4" /> Email
+            </Button>
+          )}
+          <Button variant="outline" onClick={onEdit}>
+            <Pencil className="mr-2 h-4 w-4" /> Modifica
+          </Button>
+          <Button variant="destructive" onClick={onDelete}>
+            <Trash2 className="mr-2 h-4 w-4" /> Elimina
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+

--- a/src/components/leads-detail/NotesPanel.tsx
+++ b/src/components/leads-detail/NotesPanel.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Card } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { LeadData, LeadFormData } from '@/types/leads';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+interface NotesPanelProps {
+  lead: LeadData;
+  onUpdate: (data: Partial<LeadFormData>) => Promise<boolean> | void;
+}
+
+export function NotesPanel({ lead, onUpdate }: NotesPanelProps) {
+  const [note, setNote] = useState(lead.Note || '');
+  const [esigenza, setEsigenza] = useState(lead.Esigenza || '');
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    try {
+      setSaving(true);
+      const ok = await onUpdate({ Note: note, Esigenza: esigenza });
+      if (ok) {
+        toast.success('Note aggiornate');
+      } else {
+        toast.error("Errore nell'aggiornamento delle note");
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card className="p-4 space-y-3">
+      <div>
+        <div className="text-sm font-medium mb-1">Esigenza</div>
+        <Textarea value={esigenza} onChange={(e) => setEsigenza(e.target.value)} placeholder="Descrivi l'esigenza del lead" />
+      </div>
+      <div>
+        <div className="text-sm font-medium mb-1">Note</div>
+        <Textarea value={note} onChange={(e) => setNote(e.target.value)} placeholder="Aggiungi note interne" rows={6} />
+      </div>
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={saving}>{saving ? 'Salvataggio...' : 'Salva'}</Button>
+      </div>
+    </Card>
+  );
+}
+

--- a/src/components/leads-detail/OrdersPanel.tsx
+++ b/src/components/leads-detail/OrdersPanel.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { LeadData } from '@/types/leads';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface OrdersPanelProps {
+  lead: LeadData;
+}
+
+interface OrderItem {
+  id: string;
+  createdTime: string;
+  Data?: string | null;
+  Totale?: number | null;
+  Stato?: string | null;
+  Numero?: string | null;
+}
+
+export function OrdersPanel({ lead }: OrdersPanelProps) {
+  const ids = useMemo(() => lead.Ordini || [], [lead.Ordini]);
+  const [items, setItems] = useState<OrderItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      if (!ids.length) {
+        setItems([]);
+        setError(null);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({ ids: ids.join(',') });
+        const res = await fetch(`/api/orders?${params.toString()}`, { cache: 'no-store' });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || `HTTP ${res.status}`);
+        }
+        const json = await res.json();
+        const records = (json.records || []) as OrderItem[];
+        if (!cancelled) setItems(records);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Errore caricamento ordini');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [ids]);
+
+  const formatDate = (s?: string | null, created?: string) => {
+    const d = s ? new Date(s) : created ? new Date(created) : null;
+    return d ? d.toLocaleDateString('it-IT') : '-';
+  };
+  const formatMoney = (n?: number | null) => (typeof n === 'number' ? n.toLocaleString('it-IT', { style: 'currency', currency: 'EUR' }) : '-');
+
+  return (
+    <Card className="p-4 space-y-3">
+      {ids.length === 0 ? (
+        <div className="text-muted-foreground">Nessun ordine collegato</div>
+      ) : loading ? (
+        <div className="space-y-2">
+          {[...Array(Math.min(ids.length, 3))].map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+          ))}
+        </div>
+      ) : error ? (
+        <div className="text-sm text-red-600">Errore: {error}</div>
+      ) : items.length === 0 ? (
+        <div className="text-muted-foreground">Nessun dettaglio ordine trovato</div>
+      ) : (
+        <ul className="space-y-1 text-sm">
+          {items.map(o => (
+            <li key={o.id} className="flex flex-wrap items-center gap-3">
+              <span className="font-medium">{o.Numero || o.id}</span>
+              <span className="text-muted-foreground">{formatDate(o.Data || undefined, o.createdTime)}</span>
+              <span className="text-muted-foreground">{o.Stato || '-'}</span>
+              <span className="ml-auto">{formatMoney(o.Totale)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+

--- a/src/components/leads-detail/SummaryCards.tsx
+++ b/src/components/leads-detail/SummaryCards.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Calendar, Clock, TrendingUp, Users } from 'lucide-react';
+import { LeadData } from '@/types/leads';
+
+interface SummaryCardsProps {
+  lead: LeadData;
+  activities?: Array<{ date?: string }>;
+}
+
+function daysSince(date: string | undefined) {
+  if (!date) return '-';
+  const d = new Date(date);
+  const diff = Math.floor((Date.now() - d.getTime()) / (1000 * 60 * 60 * 24));
+  return isNaN(diff) ? '-' : diff;
+}
+
+function fmtDateIT(date: string | undefined) {
+  if (!date) return 'N/A';
+  const d = new Date(date);
+  if (isNaN(d.getTime())) return 'N/A';
+  return d.toLocaleString('it-IT', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+export function SummaryCards({ lead, activities }: SummaryCardsProps) {
+  const eta = daysSince(lead?.Data);
+  const last = activities && activities.length > 0 ? activities[0]?.date : undefined;
+  const lastAge = daysSince(last);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {/* Età Lead */}
+      <Card className="from-muted/30 to-muted/60 border-border bg-gradient-to-br">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Età Lead</CardTitle>
+          <Calendar className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{typeof eta === 'number' ? `${eta}g` : '-'}</div>
+          <p className="text-muted-foreground mt-1 text-xs">Dal {fmtDateIT(lead?.Data)}</p>
+        </CardContent>
+      </Card>
+
+      {/* Ultima Attività */}
+      <Card className="from-muted/30 to-muted/60 border-border bg-gradient-to-br">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Ultima Attività</CardTitle>
+          <Clock className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{last ? `${lastAge}g` : '-'}</div>
+          <p className="text-muted-foreground mt-1 text-xs">{fmtDateIT(last)}</p>
+        </CardContent>
+      </Card>
+
+      {/* Stato/Provenienza */}
+      <Card className="from-muted/30 to-muted/60 border-border bg-gradient-to-br">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Stato & Provenienza</CardTitle>
+          <TrendingUp className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-2">
+            <Badge variant="outline" className="text-sm">{lead.Stato}</Badge>
+            <Badge variant="secondary" className="text-xs">{lead.Provenienza}</Badge>
+          </div>
+          <p className="text-muted-foreground mt-1 text-xs">ID: {lead.ID}</p>
+        </CardContent>
+      </Card>
+
+      {/* Attività conteggio */}
+      <Card className="from-muted/30 to-muted/60 border-border bg-gradient-to-br">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Attività</CardTitle>
+          <Users className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{activities?.length ?? 0}</div>
+          <p className="text-muted-foreground mt-1 text-xs">Cronologia interazioni</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/lib/activities-cache.ts
+++ b/src/lib/activities-cache.ts
@@ -1,0 +1,73 @@
+// Cache in memoria per le attività
+interface CacheEntry {
+  data: any[];
+  timestamp: number;
+  ttl: number;
+}
+
+class ActivitiesCache {
+  private cache = new Map<string, CacheEntry>();
+  private defaultTTL = 2 * 60 * 1000; // 2 minuti
+
+  set(key: string, data: any[], ttl?: number): void {
+    this.cache.set(key, {
+      data,
+      timestamp: Date.now(),
+      ttl: ttl || this.defaultTTL,
+    });
+  }
+
+  get(key: string): any[] | null {
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+    const now = Date.now();
+    if (now - entry.timestamp > entry.ttl) {
+      this.cache.delete(key);
+      return null;
+    }
+    return entry.data;
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  has(key: string): boolean {
+    const entry = this.cache.get(key);
+    if (!entry) return false;
+    const now = Date.now();
+    if (now - entry.timestamp > entry.ttl) {
+      this.cache.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  // Genera chiave cache evitando parametri non rilevanti (es. offset)
+  generateKey(searchParams: URLSearchParams): string {
+    const relevant = new URLSearchParams();
+    const filterParams = [
+      'leadId',
+      'stato',
+      'tipo',
+      'obiettivo',
+      'priorita',
+      'dataInizio',
+      'dataFine',
+      'assegnatario',
+      'search',
+      'sortField',
+      'sortDirection',
+      'maxRecords',
+      'loadAll',
+    ];
+    for (const key of filterParams) {
+      const values = searchParams.getAll(key);
+      for (const v of values) relevant.append(key, v);
+    }
+    return relevant.toString();
+  }
+}
+
+export const activitiesCache = new ActivitiesCache();
+


### PR DESCRIPTION
Changes:\n- perf(api/activities): add next revalidate 120s and in-memory cache (ignoring offset)\n- perf(api/activities): clear cache on POST\n- chore(api/activities): reduce overly verbose logs\n\nWhy:\n- Reduce load and latency on Activities while keeping data fresh\n\nTesting:\n- First GET fills cache; next GET (<=2min) has fromCache=true\n- POST invalidates cache; subsequent GET reloads